### PR TITLE
Check for array emptyness rather than existance

### DIFF
--- a/Library/Homebrew/cmd/snemo-doctor.rb
+++ b/Library/Homebrew/cmd/snemo-doctor.rb
@@ -51,7 +51,7 @@ def system_packages_to_install
      perl-Thread-Queue
     )
     missing = packages.select { |p| true unless rpm_installed?(p) }
-    cmd.concat(missing).join(" ") if missing
+    cmd.concat(missing).join(" ") unless missing.empty?
   when "ubuntu"
     cmd = %w(apt-get install)
     packages = %w(
@@ -72,7 +72,7 @@ def system_packages_to_install
      texinfo
     )
     missing = packages.select { |p| true unless deb_installed?(p) }
-    cmd.concat(missing).join(" ") if missing
+    cmd.concat(missing).join(" ") unless missing.empty?
   end
 end
 


### PR DESCRIPTION
To prevent snemo-doctor reporting an empty list of Linux packages to
install, check list of missing packages is empty rather than its
(always) existence.

Fixes: #2

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
