### PR TITLE
Whitelist env vars needed to display X11 programs on Linux

### DIFF
--- a/.snemo/bashrc
+++ b/.snemo/bashrc
@@ -3,9 +3,13 @@ brew --version
 echo "Type \"brew ls --versions\" to list available software"
 echo "Type \"exit\" to deactivate the session"
 
-# - Useful environment/shell settings
-# - CLI colours
+# - Useful environment/shell/alias settings
+# - CLI colours for mac/linux
 export CLICOLOR=1
+if [[ "$HOMEBREW_SYSTEM" == "Linux" ]]
+then
+  alias ls="ls --color=auto"
+fi
 
 # - History search key bindings
 bind '"\e[A": history-search-backward'

--- a/Library/Homebrew/cmd/snemo-shell.rb
+++ b/Library/Homebrew/cmd/snemo-shell.rb
@@ -93,6 +93,9 @@ module Homebrew
     # dir is also visible to root
     ENV.prepend_path "ROOT_INCLUDE_PATH", HOMEBREW_PREFIX/"include/bayeux" if Formula["bayeux"].installed?
 
+    # Restore Graphical settings
+    ENV["DISPLAY"] = ENV["HOMEBREW_DISPLAY"] if ENV["HOMEBREW_DISPLAY"]
+
     # Run needed command in bash
     shellCmd = %W[
       /bin/bash

--- a/Library/Homebrew/cmd/snemo-shell.rb
+++ b/Library/Homebrew/cmd/snemo-shell.rb
@@ -94,7 +94,16 @@ module Homebrew
     ENV.prepend_path "ROOT_INCLUDE_PATH", HOMEBREW_PREFIX/"include/bayeux" if Formula["bayeux"].installed?
 
     # Restore Graphical settings
+    # DISPLAY is DISPLAY, wherever we are
     ENV["DISPLAY"] = ENV["HOMEBREW_DISPLAY"] if ENV["HOMEBREW_DISPLAY"]
+    # In Singularity, we don't set XDG_RUNTIME_DIR, and override QT_XKB_CONFIG_ROOT
+    # Otherwise forward on XDG_RUNTIME_DIR
+    if OS.linux? and File.exist?("/singularity")
+      ENV["XDG_RUNTIME_DIR"] = nil
+      ENV["QT_XKB_CONFIG_ROOT"] = "/usr/share/X11/xkb"
+    else
+      ENV["XDG_RUNTIME_DIR"] = ENV["HOMEBREW_XDG_RUNTIME_DIR"] if ENV["HOMEBREW_XDG_RUNTIME_DIR"]
+    end
 
     # Run needed command in bash
     shellCmd = %W[

--- a/README.md
+++ b/README.md
@@ -300,10 +300,9 @@ As with the `exec` command, you will need to use the `--home $HOME --bind /sps` 
 at CC-IN2P3 to share the `/sps` data directory and your `$HOME` area with the container.
 These, together with `run`, enable you to run both general and production processing, reconstruction,
 and analysis tasks at CC-IN2P3, including batch jobs. Please see their dedicated [Singularity @ CC-IN2P3 documentation](https://doc.cc.in2p3.fr/logiciels:singularity)([or in English](https://doc.cc.in2p3.fr/en:logiciels:singularity)) for further instructions.
-
 It is also possible to run graphical programs such as `root` or `flvisualize`
-in the image, but full support for this is currently in development. Please
-see [Issue #6](https://github.com/SuperNEMO-DBD/brew/issues/6) for the current status and workarounds to use graphics.
+in the image, but if you are running over an SSH connection you must have X11
+forwarding set up.
 
 Much more is possible with Singularity, with a very clear and detailed
 overview available in its [online documentation](https://www.sylabs.io/guides/2.6/user-guide/index.html).
@@ -332,15 +331,16 @@ $ docker run --rm supernemo/falaise flsimulate --help
 ```
 
 The most important distinction from Singularity is that you
-**do not** have access to your `$HOME` area or other filesystems
-inside the running container. Various ways are available to share
+**do not** have access to your `$HOME` area, other filesystems, or
+graphical connections inside the running container. Various ways are available to share
 data between the host system and container, and we defer to
 the [Docker documentation on this subject](https://docs.docker.com/storage/).
 
 # Installing Additional Packages
 If your work requires software packages not present in the installation,
 you can install them through `brew` **if** Formulae for them exist. **Note
-that at present this functionality is only supported for native installs**.
+that at present this functionality is only supported for native installs because
+Singularity only allows read-only access to the install area**.
 Use the `search` subcommand to see if the package is available:
 
 ```

--- a/bin/brew
+++ b/bin/brew
@@ -54,7 +54,8 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 # Whitelist and copy to HOMEBREW_* all variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
-           BROWSER EDITOR GIT NO_COLOR PATH VISUAL
+           BROWSER DISPLAY EDITOR GIT NO_COLOR PATH VISUAL \
+           XDG_RUNTIME_DIR QT_XKB_CONFIG_ROOT
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As discussed in #6, the `snemo-shell` environment does not set up the needed `DISPLAY` (and `XDG/QT...` env vars on Linux to allow graphical programs such as ROOT and `flsimulate-configure` to be run.

These variables are stripped by `bin/brew`, so whitelist them as `HOMEBREW_...` vars and restore in `snemo-shell`. This has been tested on native Linux and Singularity at Warwick and CC-IN2P3 with X11 forwarding and now appears to work. Once merged, the docker images will be updated.

Fixes: #6