### PR TITLE
Do not suppress warnings in snemo-shell

### DIFF
--- a/Library/Homebrew/cmd/snemo-shell.rb
+++ b/Library/Homebrew/cmd/snemo-shell.rb
@@ -61,6 +61,12 @@ module Homebrew
     ENV.setup_build_environment
     ENV["VERBOSE"] = "1"
     ENV.cxx11
+    # Filter out -w from flags so users can get build warnings as normal
+    ENV["CFLAGS"] = ENV["CFLAGS"].gsub(/ \-w /,' ')
+    ENV["CXXFLAGS"] = ENV["CXXFLAGS"].gsub(/ \-w /,' ')
+    ENV["OBJCFLAGS"] = ENV["OBJCFLAGS"].gsub(/ \-w /,' ')
+    ENV["OBJCXXFLAGS"] = ENV["OBJCXXFLAGS"].gsub(/ \-w /,' ')
+
     # List on installed keg_only deps
     deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
 


### PR DESCRIPTION
Filter out "-w" flag from brew's default shell build env so developers
will get standard default warnings when developing code.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

By default, `brew`s build environment suppresses warnings (as this is not the responsibility of a package manager to fix/highlight these). For use in development however, we do not want users of `snemo-shell` to have warnings from what they themselves are developing suppressed.

When starting `snemo-shell` filter out the `-w` flag from C/CXX/OBJC/OBJCXX flags. Warnings from brew-installed packages should still be suppressed as their include paths are marked as `isystem`.