### PR TITLE
Always use :core2 arch

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -277,11 +277,12 @@ module SharedEnvExtension
 
   # @private
   def effective_arch
-    if ARGV.build_bottle? && ARGV.bottle_arch
-      ARGV.bottle_arch
-    else
-      Hardware.oldest_cpu
-    end
+    #if ARGV.build_bottle? && ARGV.bottle_arch
+    #  ARGV.bottle_arch
+    #else
+    #  Hardware.oldest_cpu
+    #end
+    :core2
   end
 
   # @private

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -1,10 +1,11 @@
 module SharedEnvExtension
   # @private
   def effective_arch
-    if ARGV.build_bottle?
-      ARGV.bottle_arch || Hardware.oldest_cpu
-    else
-      :native
-    end
+    #if ARGV.build_bottle?
+    #  ARGV.bottle_arch || Hardware.oldest_cpu
+    #else
+    #  :native
+    #end
+    :core2
   end
 end


### PR DESCRIPTION
Some formulae such as qt5-base get very confused if supplied with
the "native" or other CPU options. Default to use core2 everywhere
for sanity.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
